### PR TITLE
Handle previously built mine

### DIFF
--- a/intermine_builder/build.sh
+++ b/intermine_builder/build.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Check if Mine exists
+if [ -d ${MINE_NAME:-biotestmine} ] && [ ! -z "$(ls -A ${MINE_NAME:-biotestmine})" ]; then
+    echo "$(date +%Y/%m/%d-%H:%M) Mine already exists"
+    echo "$(date +%Y/%m/%d-%H:%M) Gradle: build webapp"
+    ./gradlew cargoDeployRemote
+    sleep 60
+    ./gradlew cargoRedeployRemote  --stacktrace
+    exit 0
+fi
+
 set -e
 
 mkdir /home/intermine/.intermine


### PR DESCRIPTION
Right now, the build script will execute all the step
even if the mine was already built.
This commit handles that and only runs step to
deploy tomcat docker container if the mine already exists.

PR for issue #12 in [intermine_boot](https://github.com/intermine/intermine_boot)